### PR TITLE
Adds CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# The @akka/akka-admin-team owns only `.github/settings.yml`
+.github/settings.yml       @akka/akka-admin-team


### PR DESCRIPTION
See https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax

This change follows probot's [recommendation](https://github.com/probot/settings#security-implications) to prevent unwanted changes in some settings:

> one way to preserve admin/push permissions is to utilize the GitHub CodeOwners feature to set one or more administrative users as the code owner of the .github/settings.yml file.
